### PR TITLE
Fix package permissions in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,9 @@ jobs:
     name: Build container image
     runs-on: ubuntu-latest
     needs: [test, version]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Add permissions to build workflow to allow pushing container images.