### PR TITLE
Fix container image labels in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,6 +86,8 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ needs.version.outputs.version }}
+          build-args: |
+            VERSION=${{ needs.version.outputs.version }}
           extra-args: |
             --target=runtime
           containerfiles: |


### PR DESCRIPTION
Add build argument to correctly set the image version as a label on the container image.