### PR TITLE
Ensure access keys have no permissions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ kubectl apply -f examples/bucketclass.yaml
 kubectl apply -f examples/bucketaccessclass.yaml
 ```
 
+> A `BucketAccessClass` has to be explicitly configured with permission parameters.
+> Generated access keys have no permissions by default.
+
 Instantiate a `BucketClaim` and `BucketAccess` resource to create a bucket and corresponding secret:
 
 ```bash

--- a/examples/bucket.yaml
+++ b/examples/bucket.yaml
@@ -13,6 +13,6 @@ metadata:
   name: garage-test
 spec:
   bucketClaimName: garage-test
-  bucketAccessClassName: garage
+  bucketAccessClassName: garage-rw
   credentialsSecretName: bucket-creds-garage-test
   protocol: s3

--- a/examples/bucketaccessclass.yaml
+++ b/examples/bucketaccessclass.yaml
@@ -1,7 +1,7 @@
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1
 metadata:
-  name: garage
+  name: garage-rw
 driverName: garage.objectstorage.k8s.io
 authenticationType: Key
 # Specify additional parameters here.
@@ -9,5 +9,8 @@ authenticationType: Key
 #
 # parameters:
 #   owner: "false"
-#   read: "true"
-#   write: "true"
+#   read: "false"
+#   write: "false"
+parameters:
+  read: "true"
+  write: "true"

--- a/internal/driver/provisioner.go
+++ b/internal/driver/provisioner.go
@@ -260,11 +260,12 @@ type accessPermissions struct {
 }
 
 // permissions parses the bucket access permissions from BucketAccessClass parameters.
+// All permissions are disabled by default.
 func permissions(params map[string]string) (*accessPermissions, error) {
 	p := &accessPermissions{
 		owner: false,
-		read:  true,
-		write: true,
+		read:  false,
+		write: false,
 	}
 
 	if params == nil {


### PR DESCRIPTION
When a `BucketAccessClass` has no permission parameters configured,
generated access keys will have no permissions by default.

This behavior matches the Garage CLI and enforces explicitness.