### PR TITLE
Fix image URL in deployment config

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 
 images:
   - name: driver
-    newName: github.com/mpreu/cosi-driver-garage
+    newName: ghcr.io/mpreu/cosi-driver-garage/cosi-driver-garage
     newTag: 0.1.0
 
   - name: sidecar


### PR DESCRIPTION
Set the correct `ghcr.io` repository for the driver container image.