### PR TITLE
Fix image URL in deployment config

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 
 images:
   - name: driver
-    newName: ghcr.io/mpreu/cosi-driver-garage/cosi-driver-garage
+    newName: ghcr.io/mpreu/cosi-driver-garage
     newTag: 0.1.0
 
   - name: sidecar


### PR DESCRIPTION
Previous commit specified a wrong URL for the driver container image.